### PR TITLE
FDR-330: Altering if count data statement

### DIFF
--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -45,7 +45,7 @@ class ContentEntityNormalizer extends NormalizerBase {
       if ($context['use-entity'] && ($definition->getType() === 'entity_reference_revisions' || $definition->getType() == 'entity_reference')) {
         $context['er-reference'] = TRUE;
         $data = $this->serializer->normalize($field_item_list, $format, $context);
-        if (count($data > 1)) {
+        if (count($data) > 1) {
           for ($i = 1; $i < count($data); $i++) {
             $keys = array_keys($data);
             foreach ($data[$keys[$i]] as $key => $value) {


### PR DESCRIPTION
Pretty sure this is a bug with this statement, as in the previous condition we're counting the result of `$data > 1` which would be a bool (or something else?) either way, something that doesn't implement countable, which then throws this php error:
```php
Warning: count(): Parameter must be an array or an object that implements Countable in Drupal\islandora_citations\Normalizer\ContentEntityNormalizer->normalize() (line 48 of /opt/www/drupal/modules/contrib/islandora_citations/src/Normalizer/ContentEntityNormalizer.php)
``` 