### PR TITLE
FDR-330: Attempting to resolve an issue with entity reference revisions

### DIFF
--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -54,7 +54,11 @@ class ContentEntityNormalizer extends NormalizerBase {
             }
           }
         }
-        $normalized_field_items += $data;
+        foreach ($data as $entity) {
+          foreach ($entity as $key => $value) {
+            $normalized_field_items = array_merge($normalized_field_items, $entity);
+          }
+        }
       }
       elseif ($context['use-entity'] && $definition->getType() === 'typed_relation') {
         $context['rel-csl-map'] = TRUE;


### PR DESCRIPTION
Attempting to correct an issue where only the first paragraph entity reference revision object is captured, but no subsequent entity references.

Also, an attempt to solve an issue where instead of being provided within the top level array of the citation items (where the citation module can reference it) data was being buried within an additional array.

Ex. Issue can be seen here when looking for the `issued` data and how it appears within a `0` index. Additionally, the `title` data is missing entirely from the json:
```json
[
    {
        "type": "book",
        "genre": "Genre 1, Genre 2, Genre 3",
        "author": [
            {
                "given": "Lastname",
                "family": "AuthorPerson1"
            }
        ],
        "0": {
            "issued": {
                "date-parts": [
                    [
                        "2021",
                        "01",
                        "02"
                    ]
                ]
            }
        },
        "archive": "Physical Form 1, Physical Form 2, Physical Form 3"
    }
]
```

This work results in the following output instead:
```json
[
    {
        "type": "book",
        "genre": "Genre 1, Genre 2, Genre 3",
        "author": [
            {
                "given": "Lastname",
                "family": "AuthorPerson1"
            }
        ],
        "issued": {
            "date-parts": [
                [
                    "2021",
                    "01",
                    "02"
                ]
            ]
        },
        "archive": "Physical Form 1, Physical Form 2, Physical Form 3",
        "title": "City Lights Paragraph,City Parargraph 2"
    }
]
```