### PR TITLE
Issue #73: Preserve normalized output from nested Typed Relation fields inside Paragraphs

### DIFF
--- a/src/Normalizer/FieldItemListNormalizer.php
+++ b/src/Normalizer/FieldItemListNormalizer.php
@@ -37,7 +37,20 @@ class FieldItemListNormalizer extends NormalizerBase {
         }
       }
       else {
-        $field_item_values = $this->serializer->normalize($field_item, $format, $context);
+        $normalized_field_instance = $this->serializer->normalize($field_item, $format, $context);
+        if (is_array($normalized_field_instance)) {
+          foreach ($normalized_field_instance as $cslField => $normalized_value) {
+            if (arraY_key_exists($cslField, $field_item_values)) {
+              $field_item_values[$cslField] = array_merge($field_item_values[$cslField], $normalized_value);
+            }
+            else {
+              $field_item_values[$cslField] = $normalized_value;
+            }
+          }
+        }
+        else {
+          $field_item_values = $normalized_field_instance;
+        }
       }
     }
 


### PR DESCRIPTION
Resolves Issue #73.

## Scenario that this fix addresses:

Create a field structure like this:

Contributor Paragraph
  - Contributor typed relation
  
  Where Contributor Paragraph may have more than one instance.
  


Before the Field Item List normalizer was looping over Field Items and overwriting them , so only the last one was being printed.

![image](https://github.com/discoverygarden/islandora_citations/assets/82412/370b1c14-98f7-42aa-8771-caf94ff6e29f)


Now multiple names show up as expected.

![image](https://github.com/discoverygarden/islandora_citations/assets/82412/703a1c3f-3cfc-47ba-8867-da82713b3e84)
   
   
Let me know if I can provide any more info.