### PR TITLE
Wrapped names in trim()

### DIFF
--- a/src/Normalizer/NormalizerBase.php
+++ b/src/Normalizer/NormalizerBase.php
@@ -94,8 +94,8 @@ abstract class NormalizerBase extends SerializationNormalizerBase implements Nor
       }
 
       return [
-        'given' => $firstName,
-        'family' => $lastName,
+        'given' => trim($firstName),
+        'family' => trim($lastName),
       ];
     }
     catch (\Exception $e) {


### PR DESCRIPTION
Names with commas would not display properly.
e.g. 
`Thakur, . K. K. (2015).` Simulation models for between farm transmission of PRRS virus in Canadian swine herds (1–) [University of Prince Edward Island].

After fix

`Thakur, K. K. (2015).` Simulation models for between farm transmission of PRRS virus in Canadian swine herds (1–) [University of Prince Edward Island]. https://islandscholar.ca/islandora/object/ir:14608/datastream/PDF/download/citation.pdf

