### PR TITLE
purge field_permissions

### DIFF
--- a/config/install/field.storage.node.field_csl_type.yml
+++ b/config/install/field.storage.node.field_csl_type.yml
@@ -6,12 +6,9 @@ dependencies:
     module:
       - islandora_citations
   module:
-    - field_permissions
     - node
     - taxonomy
-third_party_settings:
-  field_permissions:
-    permission_type: public
+third_party_settings: { }
 id: node.field_csl_type
 field_name: field_csl_type
 entity_type: node

--- a/islandora_citations.info.yml
+++ b/islandora_citations.info.yml
@@ -4,7 +4,6 @@ description: Provides a service to manage citations.
 package: Custom
 core_version_requirement: ^10
 dependencies:
-  - drupal:field_permissions
   - drupal:node
   - drupal:taxonomy
   - controlled_access_terms:controlled_access_terms


### PR DESCRIPTION
Test: install module without requiring `field_permissions`.

See https://islandora.slack.com/archives/C019U12D44Q/p1746471725210029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the dependency on the field permissions module from the configuration and module settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->