### PR TITLE
Update TypedRelationNormalizer.php

### DIFF
--- a/src/Normalizer/TypedRelationNormalizer.php
+++ b/src/Normalizer/TypedRelationNormalizer.php
@@ -52,7 +52,6 @@ class TypedRelationNormalizer extends NormalizerBase {
     if ($rel_type == 'artist') { 
         return 'author';
     } 
-    
     if ($rel_type == 'creator') {
       return 'author';
     }

--- a/src/Normalizer/TypedRelationNormalizer.php
+++ b/src/Normalizer/TypedRelationNormalizer.php
@@ -49,9 +49,9 @@ class TypedRelationNormalizer extends NormalizerBase {
   private function formatRelTypes($rel_type) {
     $rel_type = strtolower(trim(preg_replace("/\([^)]+\)/", "", $rel_type)));
 
-    if ($rel_type == 'artist') { 
-        return 'author';
-    } 
+    if ($rel_type == 'artist') {
+      return 'author';
+    }
     if ($rel_type == 'creator') {
       return 'author';
     }

--- a/src/Normalizer/TypedRelationNormalizer.php
+++ b/src/Normalizer/TypedRelationNormalizer.php
@@ -49,6 +49,10 @@ class TypedRelationNormalizer extends NormalizerBase {
   private function formatRelTypes($rel_type) {
     $rel_type = strtolower(trim(preg_replace("/\([^)]+\)/", "", $rel_type)));
 
+    if ($rel_type == 'artist') { 
+        return 'author';
+    } 
+    
     if ($rel_type == 'creator') {
       return 'author';
     }


### PR DESCRIPTION
Adds "artist" to list of relator types that get the "author" assignment

There is no way to configure a list of roles that are recognized as "Authors" for citation purposes; this PR addresses an urgent need for Arca and probably other sites as well. 

Long-term, you'd probably want a configuration screen where custom role terms could be added, but for now this addresses a need and works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardizes relationship labels by normalizing “artist” to “author,” aligning with existing “creator” → “author” behavior.
  * Ensures consistent attribute keys, filtering, and sorting for author-related data to prevent mixed “artist”/“author” labels.
  * Unifies lists and counts so items formerly shown under “artist” now appear under “author,” improving clarity without UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->