### PR TITLE
DGI9-479 : Adding empty check on csl type.

### DIFF
--- a/src/Form/SelectCslForm.php
+++ b/src/Form/SelectCslForm.php
@@ -112,7 +112,7 @@ class SelectCslForm extends FormBase {
       if (isset($settings['id'])) {
         if ($settings['id'] == 'islandora_citations_display_citations') {
           $default_csl = !empty($settings['default_csl']) ? $settings['default_csl'] : array_values($cslItems)[0];
-          $this->blockCSLType = empty($settings['default_csl_type'] ? "" : $settings['default_csl_type']);
+          $this->blockCSLType = $settings['default_csl_type'] ?? "";
         }
       }
     }

--- a/src/Form/SelectCslForm.php
+++ b/src/Form/SelectCslForm.php
@@ -112,7 +112,7 @@ class SelectCslForm extends FormBase {
       if (isset($settings['id'])) {
         if ($settings['id'] == 'islandora_citations_display_citations') {
           $default_csl = !empty($settings['default_csl']) ? $settings['default_csl'] : array_values($cslItems)[0];
-          $this->blockCSLType = $settings['default_csl_type'];
+          $this->blockCSLType = empty($settings['default_csl_type'] ? "" : $settings['default_csl_type']);
         }
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made form selection more resilient when the default CSL type is missing or empty—now falls back to an empty string to avoid notices/errors while preserving prior rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->