### PR TITLE
[DGI9-669] Accessibility fixes - make citations block more screen-reader friendly

### DIFF
--- a/islandora_citations.libraries.yml
+++ b/islandora_citations.libraries.yml
@@ -10,3 +10,10 @@ drupal:
     - core/once
     - core/drupal
     - islandora_citations/clipboardjs
+cite_this_ux:
+  js:
+    js/cite-this-ux.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/once

--- a/js/cite-this-ux.js
+++ b/js/cite-this-ux.js
@@ -1,0 +1,112 @@
+/**
+ * @file
+ * Improves the accessibility and UX of the "Cite this" citation block.
+ *
+ * - Keeps the copy-to-clipboard button label in sync with the selected style.
+ * - Disables the button when no style is selected.
+ * - Announces citation preview changes to screen readers via a live region.
+ * - Announces clipboard copy success to screen readers.
+ */
+
+(function ($, Drupal, once) {
+  'use strict';
+
+  /**
+   * Returns the shared ARIA live region, creating it if necessary.
+   *
+   * role="status" implies aria-live="polite" and aria-atomic="true", so
+   * the whole message is read as a unit without interrupting the user.
+   *
+   * A persistent element outside the AJAX wrapper is used because Drupal
+   * AJAX replaces #formatted-citation entirely (replaceWith), which causes
+   * some screen readers (e.g. ORCA) to lose track of inline live regions.
+   */
+  function getLiveRegion() {
+    var $region = $('#cite-this-sr-announcement');
+    if (!$region.length) {
+      $region = $('<div>', {
+        id: 'cite-this-sr-announcement',
+        role: 'status',
+        'aria-live': 'polite',
+        'aria-atomic': 'true',
+      }).addClass('visually-hidden').appendTo('body');
+    }
+    return $region;
+  }
+
+  /**
+   * Writes a message to the live region so screen readers announce it.
+   *
+   * Clearing before setting gives browsers/SRs a fresh mutation to detect,
+   * which is necessary when the same message is announced twice in a row.
+   */
+  function announce(message) {
+    var $region = getLiveRegion();
+    $region.empty();
+    setTimeout(function () {
+      $region.text(message);
+    }, 50);
+  }
+
+  Drupal.behaviors.citeThisUx = {
+    attach: function (context) {
+      once('cite-this-ux', 'select[name="csl_list"]', context).forEach(function (select) {
+        var $select = $(select);
+        var $form = $select.closest('form');
+        var $button = $form.find('.clipboard-button');
+
+        // Tracks the currently selected style name for use in announcements.
+        var currentStyleName = '';
+
+        // --- Button label + disabled state ---
+        function updateButton() {
+          var val = $select.val();
+          currentStyleName = val ? $select.find('option:selected').text().trim() : '';
+          var label = val
+            ? Drupal.t('Copy @style citation to clipboard', {'@style': currentStyleName})
+            : Drupal.t('Copy citation to clipboard');
+          $button.val(label).attr('aria-label', label).prop('disabled', !val);
+        }
+
+        updateButton();
+
+        $select.on('change.citeThisUx', function () {
+          updateButton();
+          // Announce the new selection. On fast connections the MutationObserver
+          // fires soon after and its announcement supersedes this one; on slower
+          // connections the user hears both in sequence.
+          if (currentStyleName) {
+            announce(Drupal.t('@style selected', {'@style': currentStyleName}));
+          }
+        });
+
+        // --- Announce citation preview changes ---
+        // Drupal AJAX replaces #formatted-citation entirely (replaceWith), so
+        // we observe its parent for childList mutations rather than the element
+        // itself. The parent persists across AJAX calls.
+        var citationEl = document.getElementById('formatted-citation');
+        if (citationEl && citationEl.parentNode) {
+          var observer = new MutationObserver(function () {
+            var message = currentStyleName
+              ? Drupal.t('Citation preview updated, showing @style.', {'@style': currentStyleName})
+              : Drupal.t('Citation preview updated.');
+            announce(message);
+          });
+          observer.observe(citationEl.parentNode, {childList: true});
+        }
+
+        // --- Announce clipboard copy success ---
+        // clipboard.js fires its success event asynchronously; a short delay
+        // ensures the copy has completed before we announce it.
+        $button.on('click.citeThisUx', function () {
+          if (!$(this).prop('disabled')) {
+            setTimeout(function () {
+              announce(Drupal.t('Citation copied to clipboard.'));
+            }, 100);
+          }
+        });
+      });
+    }
+  };
+
+})(jQuery, Drupal, once);

--- a/src/Form/SelectCslForm.php
+++ b/src/Form/SelectCslForm.php
@@ -150,6 +150,12 @@ class SelectCslForm extends FormBase {
       ],
     ];
 
+    // Attach JS for dynamic button label, disabled state when no style is
+    // selected, and screen reader announcements for citation changes and
+    // clipboard copy via a persistent live region (more reliable than
+    // aria-live on the AJAX-replaced #formatted-citation element).
+    $form['#attached']['library'][] = 'islandora_citations/cite_this_ux';
+
     return $form;
   }
 


### PR DESCRIPTION
# What does this PR do?
Make the citations block more screen-reader friendly:

- The copy button's state and aria-label is informed by the selected citation style.
  - If no style is selected, the copy button is disabled.
  - Otherwise, the copy button's aria-label includes the style of the citation to be copied.
- Screen reader announcements for style selection, preview updates, and copy confirmation.

The changes here are from work done by @patdunlavey that was just going to be constrained to the dgi base theme, but these fixes make more sense to live in the public module that the citation block is created by so it isn't dependent on any theme and can be more widely beneficial.

## How to test

1. Bring up an environment that uses this module and has the citations block placed.
2. Pull in the changes from this PR (and clear drupal caches to make sure the new js is loaded)
3. Try using any screen-reader tool to navigate the citations block and see that the changes noted above are present and haven't broken any existing functionality (I tested with VoiceOver since my work laptop is a mac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Cite this" accessibility with screen reader announcements for style selection and clipboard copy actions
  * Improved citation button feedback and dynamic label/state management based on selected citation style
  * Added persistent live region for reliable screen reader notifications on citation updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->